### PR TITLE
chore: Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+# Description
+
+[description]
+
+medic/pipeline#[number]
+
+# Code review checklist
+<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
+- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
+- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
+- [ ] Tested: Unit and/or e2e where appropriate
+- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
+
+# License
+
+The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.


### PR DESCRIPTION
Adds a PR template to the CHT Pipeline repo. Inspired by [cht-interoperability PR template](https://github.com/medic/cht-interoperability/tree/main/.github).