### PR TITLE
141 handle contact and data record deletes with root

### DIFF
--- a/models/contacts/contact.sql
+++ b/models/contacts/contact.sql
@@ -14,7 +14,7 @@
 }}
 
 SELECT
-  _id as uuid,
+  document_metadata.uuid as uuid,
   document_metadata.saved_timestamp,
   to_timestamp((NULLIF(doc ->> 'reported_date'::text, ''::text)::bigint / 1000)::double precision) AS reported,
   doc->'parent'->>'_id' AS parent_uuid,

--- a/models/contacts/contact.sql
+++ b/models/contacts/contact.sql
@@ -3,6 +3,7 @@
     materialized = 'incremental',
     unique_key='uuid',
     on_schema_change='append_new_columns',
+    post_hook='delete from {{this}} where deleted=true',
     indexes=[
       {'columns': ['uuid'], 'type': 'hash'},
       {'columns': ['saved_timestamp']},
@@ -25,7 +26,8 @@ SELECT
   doc->>'is_active' AS active,
   doc->>'notes' AS notes,
   doc->>'contact_id' AS contact_id,
-  NULLIF(doc->> 'muted', '') AS muted
+  NULLIF(doc->> 'muted', '') AS muted,
+  source_table._deleted as deleted
 FROM {{ ref('document_metadata') }} document_metadata
 INNER JOIN
   {{ env_var('POSTGRES_SCHEMA') }}.{{ env_var('POSTGRES_TABLE') }} source_table

--- a/models/contacts/contact.sql
+++ b/models/contacts/contact.sql
@@ -3,7 +3,6 @@
     materialized = 'incremental',
     unique_key='uuid',
     on_schema_change='append_new_columns',
-    post_hook='delete from {{this}} where deleted=true',
     indexes=[
       {'columns': ['uuid'], 'type': 'hash'},
       {'columns': ['saved_timestamp']},
@@ -26,8 +25,7 @@ SELECT
   doc->>'is_active' AS active,
   doc->>'notes' AS notes,
   doc->>'contact_id' AS contact_id,
-  NULLIF(doc->> 'muted', '') AS muted,
-  source_table._deleted as deleted
+  NULLIF(doc->> 'muted', '') AS muted
 FROM {{ ref('document_metadata') }} document_metadata
 INNER JOIN
   {{ env_var('POSTGRES_SCHEMA') }}.{{ env_var('POSTGRES_TABLE') }} source_table

--- a/models/contacts/contact.sql
+++ b/models/contacts/contact.sql
@@ -32,6 +32,7 @@ INNER JOIN
   ON source_table._id = document_metadata.uuid
 WHERE
   document_metadata.doc_type IN ('contact', 'clinic', 'district_hospital', 'health_center', 'person')
+  AND document_metadata._deleted = false
 {% if is_incremental() %}
   AND document_metadata.saved_timestamp >= {{ max_existing_timestamp('saved_timestamp') }}
 {% endif %}

--- a/models/contacts/contacts.yml
+++ b/models/contacts/contacts.yml
@@ -9,9 +9,14 @@ models:
       - name: uuid
         data_type: string
         constraints:
+          - type: foreign_key
+            expression: "{{ env_var('POSTGRES_SCHEMA') }}.document_metadata (uuid) ON DELETE CASCADE"
           - type: unique
         tests:
           - not_null
+          - relationships:
+              to: ref('document_metadata')
+              field: uuid
       - name: saved_timestamp
         data_type: timestamp
       - name: reported
@@ -36,9 +41,6 @@ models:
         data_type: string
       - name: muted
         data_type: string
-      - name: deleted
-        data_type: boolean
-
   - name: person
     config:
       contract:

--- a/models/contacts/contacts.yml
+++ b/models/contacts/contacts.yml
@@ -36,6 +36,8 @@ models:
         data_type: string
       - name: muted
         data_type: string
+      - name: deleted
+        data_type: boolean
 
   - name: person
     config:

--- a/models/forms/data_record.sql
+++ b/models/forms/data_record.sql
@@ -3,6 +3,7 @@
     materialized = 'incremental',
     unique_key='uuid',
     on_schema_change='append_new_columns',
+    post_hook='delete from {{this}} where deleted=true',
     indexes=[
       {'columns': ['uuid'], 'type': 'hash'},
       {'columns': ['saved_timestamp']},
@@ -37,7 +38,8 @@ SELECT
 
   doc->'contact'->>'_id' as contact_uuid,
   doc->'contact'->'parent'->>'_id' as parent_uuid,
-  doc->'contact'->'parent'->'parent'->>'_id' as grandparent_uuid
+  doc->'contact'->'parent'->'parent'->>'_id' as grandparent_uuid,
+  source_table._deleted as deleted
 
 FROM {{ ref('document_metadata') }} document_metadata
 INNER JOIN

--- a/models/forms/data_record.sql
+++ b/models/forms/data_record.sql
@@ -3,7 +3,6 @@
     materialized = 'incremental',
     unique_key='uuid',
     on_schema_change='append_new_columns',
-    post_hook='delete from {{this}} where deleted=true',
     indexes=[
       {'columns': ['uuid'], 'type': 'hash'},
       {'columns': ['saved_timestamp']},
@@ -38,9 +37,7 @@ SELECT
 
   doc->'contact'->>'_id' as contact_uuid,
   doc->'contact'->'parent'->>'_id' as parent_uuid,
-  doc->'contact'->'parent'->'parent'->>'_id' as grandparent_uuid,
-  source_table._deleted as deleted
-
+  doc->'contact'->'parent'->'parent'->>'_id' as grandparent_uuid
 FROM {{ ref('document_metadata') }} document_metadata
 INNER JOIN
   {{ env_var('POSTGRES_SCHEMA') }}.{{ env_var('POSTGRES_TABLE') }} source_table

--- a/models/forms/data_record.sql
+++ b/models/forms/data_record.sql
@@ -18,7 +18,7 @@
 }}
 
 SELECT
-  _id as uuid,
+  document_metadata.uuid as uuid,
   document_metadata.saved_timestamp,
   to_timestamp((NULLIF(doc->>'reported_date'::text, ''::text)::bigint / 1000)::double precision) AS reported,
   doc->>'form' as form,

--- a/models/forms/data_record.sql
+++ b/models/forms/data_record.sql
@@ -44,6 +44,7 @@ INNER JOIN
   ON source_table._id = document_metadata.uuid
 WHERE
   document_metadata.doc_type = 'data_record'
+  AND document_metadata._deleted = false
 {% if is_incremental() %}
   AND document_metadata.saved_timestamp >= {{ max_existing_timestamp('saved_timestamp') }}
 {% endif %}

--- a/models/forms/forms.yml
+++ b/models/forms/forms.yml
@@ -30,3 +30,5 @@ models:
         data_type: string
       - name: grandparent_uuid
         data_type: string
+      - name: deleted
+        data_type: boolean

--- a/models/forms/forms.yml
+++ b/models/forms/forms.yml
@@ -9,9 +9,14 @@ models:
       - name: uuid
         data_type: string
         constraints:
+          - type: foreign_key
+            expression: "{{ env_var('POSTGRES_SCHEMA') }}.document_metadata (uuid) ON DELETE CASCADE"
           - type: unique
         tests:
           - not_null
+          - relationships:
+              to: ref('document_metadata')
+              field: uuid
       - name: saved_timestamp
         data_type: timestamp
       - name: reported
@@ -30,5 +35,3 @@ models:
         data_type: string
       - name: grandparent_uuid
         data_type: string
-      - name: deleted
-        data_type: boolean

--- a/models/root/document_metadata.sql
+++ b/models/root/document_metadata.sql
@@ -3,16 +3,19 @@
     materialized = 'incremental',
     unique_key='uuid',
     on_schema_change='append_new_columns',
+    post_hook='delete from {{this}} where _deleted=true',
     indexes=[
       {'columns': ['uuid'], 'type': 'hash'},
       {'columns': ['saved_timestamp']},
       {'columns': ['doc_type']},
+      {'columns': ['_deleted']},
     ]
   )
 }}
 
 SELECT
   _id as uuid,
+  _deleted,
   saved_timestamp,
   doc->>'type' as doc_type
 FROM {{ env_var('POSTGRES_SCHEMA') }}.{{ env_var('POSTGRES_TABLE') }} source_table

--- a/models/root/root.yml
+++ b/models/root/root.yml
@@ -20,5 +20,7 @@ models:
           - not_null
       - name: saved_timestamp
         data_type: timestamp
+      - name: _deleted
+        data_type: boolean
       - name: doc_type
         data_type: string

--- a/models/users/user.sql
+++ b/models/users/user.sql
@@ -11,7 +11,7 @@
 }}
 
 SELECT
-  _id as user_id,
+  document_metadata.uuid as user_id,
   document_metadata.saved_timestamp,
   COALESCE(
     doc->>'contact_id',
@@ -25,6 +25,7 @@ INNER JOIN
   ON source_table._id = document_metadata.uuid
 WHERE
   document_metadata.doc_type = 'user-settings'
+  AND document_metadata._deleted = false
 {% if is_incremental() %}
   AND document_metadata.saved_timestamp >= {{ max_existing_timestamp('saved_timestamp') }}
 {% endif %}

--- a/models/users/user.yml
+++ b/models/users/user.yml
@@ -11,7 +11,7 @@ models:
         constraints:
           - type: unique
           - type: foreign_key
-            expression: "{{ env_var('POSTGRES_SCHEMA') }}.contact (uuid) ON DELETE CASCADE"
+            expression: "{{ env_var('POSTGRES_SCHEMA') }}.document_metadata (uuid) ON DELETE CASCADE"
         tests:
           - not_null
           - relationships:

--- a/test/sqltest/contact.sql
+++ b/test/sqltest/contact.sql
@@ -5,10 +5,17 @@ WHERE
   couchdb.doc->>'type' IN ('contact', 'clinic', 'district_hospital', 'health_center', 'person')
   -- TEST CONDITIONS
   AND (
-    -- in couchdb, not in contact table
-    (contact.uuid IS NULL)
-    OR -- fields dont match
-    contact.parent_uuid <> couchdb.doc->'parent'->>'_id' OR
-    contact.contact_type <> COALESCE(couchdb.doc->>'contact_type', couchdb.doc->>'type') OR
-    contact.phone <> couchdb.doc->>'phone'
+    (
+      -- in couchdb, not in contact table
+      (contact.uuid IS NULL)
+      OR -- fields dont match
+      contact.parent_uuid <> couchdb.doc->'parent'->>'_id' OR
+      contact.contact_type <> COALESCE(couchdb.doc->>'contact_type', couchdb.doc->>'type') OR
+      contact.phone <> couchdb.doc->>'phone'
+    )
+    OR 
+    (
+      -- contact has deleted flag
+      couchdb.doc->>'_deleted' = 'true'
+    )
   )

--- a/test/sqltest/contact.sql
+++ b/test/sqltest/contact.sql
@@ -5,17 +5,12 @@ WHERE
   couchdb.doc->>'type' IN ('contact', 'clinic', 'district_hospital', 'health_center', 'person')
   -- TEST CONDITIONS
   AND (
-    (
-      -- in couchdb, not in contact table
-      (contact.uuid IS NULL)
-      OR -- fields dont match
-      contact.parent_uuid <> couchdb.doc->'parent'->>'_id' OR
-      contact.contact_type <> COALESCE(couchdb.doc->>'contact_type', couchdb.doc->>'type') OR
-      contact.phone <> couchdb.doc->>'phone'
-    )
-    OR 
-    (
-      -- contact has deleted flag
-      couchdb.doc->>'_deleted' = 'true'
-    )
+    -- in couchdb, not in contact table
+    (contact.uuid IS NULL)
+    OR -- fields dont match
+    contact.parent_uuid <> couchdb.doc->'parent'->>'_id' OR
+    contact.contact_type <> COALESCE(couchdb.doc->>'contact_type', couchdb.doc->>'type') OR
+    contact.phone <> couchdb.doc->>'phone'
+    OR -- deleted is true
+    (contact.deleted = true)
   )

--- a/test/sqltest/contact.sql
+++ b/test/sqltest/contact.sql
@@ -5,12 +5,13 @@ WHERE
   couchdb.doc->>'type' IN ('contact', 'clinic', 'district_hospital', 'health_center', 'person')
   -- TEST CONDITIONS
   AND (
-    -- in couchdb, not in contact table
-    (contact.uuid IS NULL)
+    -- in couchdb, not deleted, but not in contact table
+    (contact.uuid IS NULL AND couchdb._deleted = false)
+    OR
+    -- in couchdb, deleted, but still in contact table
+    (contact.uuid IS NOT NULL AND couchdb._deleted = true)
     OR -- fields dont match
     contact.parent_uuid <> couchdb.doc->'parent'->>'_id' OR
     contact.contact_type <> COALESCE(couchdb.doc->>'contact_type', couchdb.doc->>'type') OR
     contact.phone <> couchdb.doc->>'phone'
-    OR -- deleted is true
-    (contact.deleted = true)
   )

--- a/test/sqltest/data_record.sql
+++ b/test/sqltest/data_record.sql
@@ -5,11 +5,18 @@ WHERE
   couchdb.doc->>'type' = 'data_record'
   -- TEST CONDITIONS
   AND (
-    -- in couchdb, not in data_record
-    (data_record.uuid IS NULL)
-    OR -- fields dont match
-    data_record.from_phone <> couchdb.doc->>'from' OR
-    data_record.form <> couchdb.doc->>'form' OR
-    data_record.patient_id <> couchdb.doc->>'patient_id' OR
-    data_record.contact_uuid <> couchdb.doc->'contact'->>'_id'
+    (
+      -- in couchdb, not in data_record
+      (data_record.uuid IS NULL)
+      OR -- fields dont match
+      data_record.from_phone <> couchdb.doc->>'from' OR
+      data_record.form <> couchdb.doc->>'form' OR
+      data_record.patient_id <> couchdb.doc->>'patient_id' OR
+      data_record.contact_uuid <> couchdb.doc->'contact'->>'_id'
+    )
+    OR 
+    (
+      -- contact has deleted flag
+      couchdb.doc->>'_deleted' = 'true'
+    )
   )

--- a/test/sqltest/data_record.sql
+++ b/test/sqltest/data_record.sql
@@ -5,13 +5,14 @@ WHERE
   couchdb.doc->>'type' = 'data_record'
   -- TEST CONDITIONS
   AND (
-    -- in couchdb, not in data_record
-    (data_record.uuid IS NULL)
+    -- in couchdb, not deleted, but not in data_record
+    (data_record.uuid IS NULL AND couchdb._deleted = false)
+    OR
+    -- in couchdb, deleted, but in data_record
+    (data_record.uuid IS NOT NULL AND couchdb._deleted = true)
     OR -- fields dont match
     data_record.from_phone <> couchdb.doc->>'from' OR
     data_record.form <> couchdb.doc->>'form' OR
     data_record.patient_id <> couchdb.doc->>'patient_id' OR
     data_record.contact_uuid <> couchdb.doc->'contact'->>'_id'
-    OR -- deleted is true
-    (data_record.deleted = true)
   )

--- a/test/sqltest/data_record.sql
+++ b/test/sqltest/data_record.sql
@@ -5,18 +5,13 @@ WHERE
   couchdb.doc->>'type' = 'data_record'
   -- TEST CONDITIONS
   AND (
-    (
-      -- in couchdb, not in data_record
-      (data_record.uuid IS NULL)
-      OR -- fields dont match
-      data_record.from_phone <> couchdb.doc->>'from' OR
-      data_record.form <> couchdb.doc->>'form' OR
-      data_record.patient_id <> couchdb.doc->>'patient_id' OR
-      data_record.contact_uuid <> couchdb.doc->'contact'->>'_id'
-    )
-    OR 
-    (
-      -- contact has deleted flag
-      couchdb.doc->>'_deleted' = 'true'
-    )
+    -- in couchdb, not in data_record
+    (data_record.uuid IS NULL)
+    OR -- fields dont match
+    data_record.from_phone <> couchdb.doc->>'from' OR
+    data_record.form <> couchdb.doc->>'form' OR
+    data_record.patient_id <> couchdb.doc->>'patient_id' OR
+    data_record.contact_uuid <> couchdb.doc->'contact'->>'_id'
+    OR -- deleted is true
+    (data_record.deleted = true)
   )

--- a/test/sqltest/patient.sql
+++ b/test/sqltest/patient.sql
@@ -2,6 +2,8 @@ SELECT
 FROM v1.couchdb couchdb
 LEFT JOIN {{ ref('patient') }} patient ON couchdb._id = patient.uuid
 WHERE
+  couchdb._deleted = false
+  AND
   (
     (couchdb.doc->>'type' = 'person') OR
     (couchdb.doc->>'type' = 'contact' AND couchdb.doc->>'contact_type' = 'person')

--- a/test/sqltest/person.sql
+++ b/test/sqltest/person.sql
@@ -4,6 +4,8 @@ LEFT JOIN {{ ref('person') }} person ON couchdb._id = person.uuid
 LEFT JOIN {{ ref('contact') }} contact ON contact.uuid = person.uuid
 WHERE
   -- person conditions
+  couchdb._deleted = false
+  AND
   (
     (couchdb.doc->>'type' = 'person') OR
     (couchdb.doc->>'type' = 'contact' AND couchdb.doc->>'contact_type' = 'person')

--- a/test/sqltest/user.sql
+++ b/test/sqltest/user.sql
@@ -1,0 +1,13 @@
+SELECT
+FROM {{ env_var('POSTGRES_SCHEMA') }}.{{ env_var('POSTGRES_TABLE') }} couchdb
+LEFT JOIN {{ ref('user') }} cht_user ON couchdb._id = cht_user.user_id
+WHERE
+  couchdb.doc->>'type' = 'user-settings'
+  -- TEST CONDITIONS
+  AND (
+    -- in couchdb, not deleted, but not in user table
+    (cht_user.user_id IS NULL AND couchdb._deleted = false)
+    OR
+    -- in couchdb, deleted, but still in user table
+    (cht_user.user_id IS NOT NULL AND couchdb._deleted = true)
+  )


### PR DESCRIPTION
@njuguna-n this is an alternative to https://github.com/medic/cht-pipeline/pull/142/ which uses the document_metadata table and cascading FK deletes to manage downstream models, instead of adding deleted columns to all the downstream models. 