### PR TITLE
fix(#165): removing potentially ambiguous date format

### DIFF
--- a/models/contacts/person.sql
+++ b/models/contacts/person.sql
@@ -16,7 +16,6 @@ SELECT
   CASE
     WHEN NULLIF(couchdb.doc->>'date_of_birth', '') IS NULL THEN NULL
     WHEN couchdb.doc->>'date_of_birth' ~ '^\d{4}-\d{2}-\d{2}$' THEN (couchdb.doc->>'date_of_birth')::date
-    WHEN couchdb.doc->>'date_of_birth' ~ '^\d{2}/\d{2}/\d{4}$' THEN TO_DATE(couchdb.doc->>'date_of_birth', 'DD/MM/YYYY')
     ELSE NULL
   END as date_of_birth,
   couchdb.doc->>'sex' as sex,


### PR DESCRIPTION
the previous commit failed because it recognized '10/15/1998' as a valid date format, but then tried to interpret it as 'DD/MM/YYYY' which failed because month can't be 15.

In the original issue, I said it should be a permissive as possible, but now I think it should default to null if there's any possiblity for ambiguity, so only support YYYY-MM-DD and default anything else to NULL

This condition still isn't perfect, because there's a possibility for errors when something is formatted like 1234-56-78 but is not a valid date, but Im not sure if there's a better way...if that case every actually happened, it might be necessarry to fix the data rather than trying to address everything in the case statement.

The other option could be to check for valid dates in the case condition...which would get messy, and we would want to move it to a dbt macro.

so this could be a quick fix to the current problem.
We also need to do something similar for patient_f_client (I don't have access to that repo)