### PR TITLE
fix: add extra validation to date format

### DIFF
--- a/models/contacts/person.sql
+++ b/models/contacts/person.sql
@@ -15,7 +15,11 @@ SELECT
   contact.saved_timestamp,
   CASE
     WHEN NULLIF(couchdb.doc->>'date_of_birth', '') IS NULL THEN NULL
-    WHEN couchdb.doc->>'date_of_birth' ~ '^\d{4}-\d{2}-\d{2}$' THEN (couchdb.doc->>'date_of_birth')::date
+    WHEN couchdb.doc->>'date_of_birth' ~ '^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$' THEN
+        CASE
+            WHEN couchdb.doc->>'date_of_birth' IS NOT NULL AND TO_DATE(couchdb.doc->>'date_of_birth', 'YYYY-MM-DD')::text = couchdb.doc->>'date_of_birth' THEN TO_DATE(couchdb.doc->>'date_of_birth', 'YYYY-MM-DD')
+            ELSE NULL
+        END
     ELSE NULL
   END as date_of_birth,
   couchdb.doc->>'sex' as sex,


### PR DESCRIPTION
# Description

Add extra validation in the date casting. a date with the format `1997-00-26` still caused an error

medic/pipeline#[number]

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.