### PR TITLE
chore: add env directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ logs/
 tests/.user.yml
 dbt-env/*
 .user.yml
-dbt-env/*
 .idea
 .DS_Store
 env/
+venv/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 target/
 dbt_modules/
 dbt_packages/
@@ -11,3 +10,4 @@ dbt-env/*
 dbt-env/*
 .idea
 .DS_Store
+env/


### PR DESCRIPTION
# Description

- Add `env` and `venv` directory to gitignore as these directories are created most of the time for creating python venv to work with dbt directly. 
- Remove duplicate entry for dbt-env

# License
The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.