### PR TITLE
Add inactive and deletion_date fields to user-settings documents

### DIFF
--- a/models/users/user.sql
+++ b/models/users/user.sql
@@ -17,6 +17,8 @@ SELECT
     doc->>'contact_id',
     doc->>'facility_id'
   ) as contact_uuid,
+  doc->>'inactive' as inactive,
+  TO_CHAR(TO_TIMESTAMP((doc->>'deletion_date')::bigint / 1000), 'YYYY/MM/DD') as deletion_date,
   doc->>'language' as language,
   doc->>'roles' as roles
 FROM {{ ref('document_metadata') }} document_metadata

--- a/models/users/user.sql
+++ b/models/users/user.sql
@@ -17,7 +17,7 @@ SELECT
     doc->>'contact_id',
     doc->>'facility_id'
   ) as contact_uuid,
-  doc->>'inactive' as inactive,
+  (doc->>'inactive')::boolean as inactive,
   TO_CHAR(TO_TIMESTAMP((doc->>'deletion_date')::bigint / 1000), 'YYYY/MM/DD') as deletion_date,
   doc->>'language' as language,
   doc->>'roles' as roles

--- a/models/users/user.yml
+++ b/models/users/user.yml
@@ -29,6 +29,10 @@ models:
           - relationships:
               to: ref('contact')
               field: uuid
+      - name: inactive
+        data_type: boolean
+      - name: deletion_date
+        data_type: string
       - name: language
         data_type: string
       - name: roles

--- a/tests/fixtures/user/user_document_metadata_initial.csv
+++ b/tests/fixtures/user/user_document_metadata_initial.csv
@@ -3,6 +3,7 @@ uuid,_deleted,saved_timestamp,doc_type
 2,false,2024-08-01 00:00:00,user-settings
 3,false,2024-08-02 00:00:00,user-settings
 4,false,2024-08-02 00:00:00,user-settings
+10,false,2024-08-03 00:00:00,user-settings
 5,true,2024-08-02 00:00:00,other-type
 6,false,2024-08-02 00:00:00,feedback
 7,true,2024-08-02 00:00:00,feedback

--- a/tests/fixtures/user/user_initial_expected.csv
+++ b/tests/fixtures/user/user_initial_expected.csv
@@ -1,7 +1,8 @@
-user_id,saved_timestamp,contact_uuid,language,roles
-1,2024-08-01 00:00:00,1001,en,admin
-2,2024-08-01 00:00:00,1002,fr,user
-3,2024-08-02 00:00:00,1003,es,guest
-4,2024-08-02 00:00:00,1004,de,user
+user_id,saved_timestamp,contact_uuid,inactive,deletion_date,language,roles
+1,2024-08-01 00:00:00,1001,,,en,admin
+2,2024-08-01 00:00:00,1002,,,fr,user
+3,2024-08-02 00:00:00,1003,,,es,guest
+4,2024-08-02 00:00:00,1004,,,de,user
+10,2024-08-03 00:00:00,1010,true,2026/05/08,en,user
 
 

--- a/tests/fixtures/user/user_source_table_initial.csv
+++ b/tests/fixtures/user/user_source_table_initial.csv
@@ -3,6 +3,7 @@ saved_timestamp,_id,_deleted,doc
 2024-08-01 00:00:00,2,false,"{""type"": ""user-settings"", ""facility_id"": ""1002"", ""language"": ""fr"", ""roles"": ""user""}"
 2024-08-02 00:00:00,3,false,"{""type"": ""user-settings"", ""contact_id"": ""1003"", ""language"": ""es"", ""roles"": ""guest""}"
 2024-08-02 00:00:00,4,false,"{""type"": ""user-settings"", ""contact_id"": ""1004"", ""language"": ""de"", ""roles"": ""user""}"
+2024-08-03 00:00:00,10,false,"{""type"": ""user-settings"", ""contact_id"": ""1010"", ""inactive"": true, ""deletion_date"": 1778236962564, ""language"": ""en"", ""roles"": ""user""}"
 2024-08-02 00:00:00,5,true,"{""type"": ""other-type"", ""contact_id"": ""1005"", ""language"": ""it"", ""roles"": ""admin""}"
 2024-08-02 00:00:00,6,false,"{""type"": ""feedback"", ""meta"": {""source"": ""automatic"", ""url"": ""http://example.com"", ""time"": ""2024-08-02 00:00:00"", ""user"": {""name"": ""admin""}}, ""info"": {""cause"": ""bug"", ""message"": ""this is a bug""}}"
 2024-08-02 00:00:00,7,true,"{""type"": ""feedback"", ""meta"": {""source"": ""automatic"", ""url"": ""http://example.com"", ""time"": ""2024-08-02 00:00:00"", ""user"": {""name"": ""admin""}}, ""info"": {""cause"": ""bug"", ""message"": ""this is a bug""}}"


### PR DESCRIPTION
# Summary
This PR adds two new fields to the user model to improve telemetry reporting accuracy:
- `inactive`: Boolean field indicating whether a user is inactive
- `deletion_date`: Date field showing when a user was deleted, converted from Unix timestamp (milliseconds) to `YYYY/MM/DD` format

# Issue

Resolving #195 
 
## Changes
- **models/users/user.sql**: Added extraction and conversion of `inactive` and `deletion_date` fields from CouchDB JSON documents
- **models/users/user.yml**: Added column definitions for `inactive` (boolean) and `deletion_date` (string) with proper data types
 
## Technical Details
The `deletion_date` field is stored in CouchDB as a Unix timestamp in milliseconds (e.g., `1778236962564`). This PR converts it to a human-readable `YYYY/MM/DD` format using PostgreSQL:
```sql
TO_CHAR(TO_TIMESTAMP((doc->>'deletion_date')::bigint / 1000), 'YYYY/MM/DD')